### PR TITLE
Fix Various HTTP 403 Bugs

### DIFF
--- a/js/controllers/vizCreatorController.js
+++ b/js/controllers/vizCreatorController.js
@@ -47,7 +47,7 @@ const vizCreatorController = {
         this.vizCreatorModel.audio.selectedSongURL = songURL;
         this.vizCreatorModel.audio.artistName = artistName;
         this.vizCreatorModel.audio.trackName = trackName;
-        this.audioPlayerView.audioPlayer.loadAudio(`${this.getProxyURL()}/${songURL}`);
+        this.audioPlayerView.audioPlayer.loadAudio(`${songURL}`);
     },
 
     // getAudioPlayerStatus() {

--- a/js/views/chooseSongOverlayView.js
+++ b/js/views/chooseSongOverlayView.js
@@ -28,7 +28,7 @@ const chooseSongOverlayView = {
                     // clear previous results
                     this.searchResultsDOMElem.innerHTML = "";
                     
-                    const response = await fetch(`${appConfig.BACKEND_URL}/track/?song=${songToSearch}`);
+                    const response = await fetch(`https://api.napster.com/v2.2/search?apikey=ZDIxMDM1NTEtYjk3OS00YTI1LWIyYjItYjBjOWVmMWYyN2I3&query=${songToSearch}&type=track`);
 
                     const results = await response.json();
                     console.log(results);

--- a/js/viz/galleryCanvas.js
+++ b/js/viz/galleryCanvas.js
@@ -28,7 +28,7 @@ function galleryCanvas(vizData, controller, proxyUrl) {
         sketch.preload = () => {
             sketch.soundFormats('mp3');
             if (vizData.songURL != null) {
-                sketch.song = sketch.loadSound(`${proxyUrl}/${vizData.songURL}`);
+                sketch.song = sketch.loadSound(`${vizData.songURL}`);
             }
         }
 


### PR DESCRIPTION
Some recent changes to the Napster API broke GET requests made by the app.
- The API does not seem to accept requests from non-browsers anymore, throwing 403 Forbidden. Therefore, API requests made from the backend aren't possible anymore. As a result, move all API requests to the frontend. Unfortunately this exposes the API key, but it's necessary to preserve critical functionality until I can find a solution
- Whereever the mp3 files are hosted doesn't require me to use a CORS proxy server anymore and in fact blocks the request if I use one, so stop using a proxy server.