### PR TITLE
ci: use supported container for db migrations

### DIFF
--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -10,7 +10,7 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     # Docker Hub image that `container-job` executes in
-    container: node:10.18-jessie
+    container: ubuntu:18.04
 
     # Service containers to run with `container-job`
     services:


### PR DESCRIPTION
Switch from node:10.18-jessie to ubuntu-18.04 for applying db schema migrations since the former is no longer supported and packages the former container is dependent on no longer exist on the remote causing the whole workflow to fail. Also, a node container is no longer used since node isn't actually used at all in the workflow.