### PR TITLE
Make db deployment manually triggered

### DIFF
--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -1,9 +1,5 @@
 name: PostgreSQL service example
-on: 
-  push:
-    branches:
-      - main
-
+on: workflow_dispatch
 jobs:
   # Label of the container job
   container-job:


### PR DESCRIPTION
Make database deployment require manual trigger, since it doesn't need to be deployed every time there's a push to main.